### PR TITLE
Fix README instructions and update base URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ A pixel-styled React portfolio site.
 npm install
 ```
 
-2. Create a `.env` file based on `.env.example` and set your Discord webhook URL:
+2. Create a `.env` file and set your Discord webhook URL:
 
 ```bash
-cp .env.example .env
-# Edit .env and set REACT_APP_DISCORD_WEBHOOK
+# .env
+REACT_APP_DISCORD_WEBHOOK="<your-discord-webhook-url>"
 ```
 
 3. Start the development server:

--- a/public/index.html
+++ b/public/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Noah Weeks | Nullgrimoire</title>
     <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
-    <base href="/pixel-portfolio/">
+    <base href="/DigitalGrimoire/">
   </head>
   <body class="bg-gray-900 text-white font-pixel">
     <div id="root"></div>

--- a/src/components/blog/BlogHome.jsx
+++ b/src/components/blog/BlogHome.jsx
@@ -3,7 +3,7 @@ import posts from "../../posts";
 
 export default function BlogHome() {
   return (
-    <div className="min-h-screen bg-gray-900 text-white pt-20"> {/* Add pt-20 */}
+    <div className="min-h-screen bg-gray-900 text-white pt-20">
       <h1 className="text-4xl text-center font-bold mb-8 border-b border-purple-500 pb-2">
       📖 Codex of Echoes
       </h1>

--- a/src/components/blog/BlogPost.jsx
+++ b/src/components/blog/BlogPost.jsx
@@ -11,7 +11,7 @@ export default function BlogPost() {
   }
 
   return (
-    <div className="min-h-screen bg-gray-900 text-white pt-20"> {/* Add pt-20 */}
+    <div className="min-h-screen bg-gray-900 text-white pt-20">
       <div className="max-w-3xl mx-auto px-4">
       <h1 className="text-4xl font-bold mb-4">{post.title}</h1>
       <p className="text-sm text-purple-400 mb-8">{post.date}</p>


### PR DESCRIPTION
## Summary
- update environment setup instructions in README
- fix GitHub pages base URL in `index.html`
- remove stray comments from blog components

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68673ed60bd4832cbec55d486dd4ee60